### PR TITLE
fix: added width of 100% to the page container

### DIFF
--- a/components/_common/page-container.tsx
+++ b/components/_common/page-container.tsx
@@ -16,6 +16,7 @@ const PageContainer: React.FC = ({ children }) => {
       flexDirection={'column'}
       background={'#000'}
       overflow='hidden'
+      width={'100%'}
     >
       <NavBar />
       <Container


### PR DESCRIPTION

Page is now responsive at every breakpoints: 
![Screenshot 2023-01-03 at 13 27 05](https://user-images.githubusercontent.com/102098836/210357208-3704b2d5-0ee4-4b53-a5fe-b169804c4ef9.png)
