### PR TITLE
`fix: chippi page and banklessdao weekly nft showcase pages on invest page for mobile (dw-190)`

### DIFF
--- a/components/invest/NftInvest.tsx
+++ b/components/invest/NftInvest.tsx
@@ -22,8 +22,8 @@ function NftInvest() {
             justifyContent='center'
             flexDirection='column'
             className='border-box'
-            width='458px'
-            height='250px'
+            width={{ base: '100%', md: '458px' }}
+            height={{ base: '300px', md: '250px' }}
           >
             <Text fontWeight={400} lineHeight='22px' fontSize='lg'>
               {`Chippi are hand-drawn 1-of-1s from BanklessDAO contributor Perchy.
@@ -60,8 +60,8 @@ function NftInvest() {
             justifyContent='center'
             flexDirection='column'
             className='border-box'
-            width='458px'
-            height='250px'
+            width={{ base: '100%', md: '458px' }}
+            height={{ base: '300px', md: '250px' }}
             margin={0}
           >
             <Text fontWeight={400} lineHeight='22px' fontSize='lg'>


### PR DESCRIPTION
fixes [dw-190](https://app.dework.xyz/banklessdao-1/website-project-2?taskId=6b8a7d6e-0b9b-4144-9871-1aa0a4aeadeb)