### PR TITLE
redirect www.bankless.community to blackflagdao.notion.site

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,17 @@
       ],
       "destination": "https://blackflagdao.notion.site/",
       "permanent": false
+    },
+    {
+      "source": "/((?!tlBank).*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "banklessdao-website.vercel.app"
+        }
+      ],
+      "destination": "https://blackflagdao.notion.site/",
+      "permanent": false
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "www.bankless.community"
+        }
+      ],
+      "destination": "https://blackflagdao.notion.site/",
+      "permanent": false
+    }
+  ]
+}


### PR DESCRIPTION
This PR should now do this (in theory):
- temporary redirect (307) of https://bankless.community/* to https://blackflagdao.notion.side/
- keep https://banklessdao-website.vercel.app/tlBank accessible
- temporary redirect (307) of https://banklessdao-website.vercel.app/* to https://blackflagdao.notion.side/
We could then follow up with hiding all the menu + footer links (= just displaying the tlBank interface).
Once we are sure everything works as expected we can switch redirect "permanent": false to true in the config file.